### PR TITLE
Request tiles by https

### DIFF
--- a/OSOpenSpace.js
+++ b/OSOpenSpace.js
@@ -53,7 +53,7 @@
       apiUrl = typeof apiUrl !== 'undefined' ? apiUrl : 'file:///';
 
       L.TileLayer.WMS.prototype.initialize.call(this,
-        'http://openspace.ordnancesurvey.co.uk/osmapapi/ts', {
+        'https://openspace.ordnancesurvey.co.uk/osmapapi/ts', {
           crs: L.OSOpenSpace.CRS,
           maxZoom: 14,
           minZoom: 0,


### PR DESCRIPTION
Fixes #15. By always requesting tiles with https there will never be any
objections from browsers about mixed content.